### PR TITLE
Add test for simulator CLI help

### DIFF
--- a/modules/simulator/README.md
+++ b/modules/simulator/README.md
@@ -1,0 +1,16 @@
+# Simulator Module
+
+This module emulates the behaviour of **QartvelSat‑1** so that the rest of the
+ground‑station stack can be tested without any physical hardware.  It will
+accept uplinked commands, mutate an in‑memory satellite state, and periodically
+emit telemetry frames over ZeroMQ.
+
+Development follows the milestones in [`TODO.md`](TODO.md).  The first goal is a
+minimal command line interface that can be executed locally:
+
+```bash
+python sim.py --help
+```
+
+Later milestones will introduce the state machine, command parsing, downlink
+payload generation, and basic orbit simulation toggles.

--- a/modules/simulator/TODO.md
+++ b/modules/simulator/TODO.md
@@ -2,7 +2,7 @@
 
 | Status |   #   | Commit Tag      | Goal                                  | Testable Result                                                |
 | :----: | :---: | --------------- | ------------------------------------- | -------------------------------------------------------------- |
-|   ⬜️   | **0** | `sim-scaffold`  | Basic project skeleton + argparse     | `python sim.py --help` prints usage.                           |
+|   ☑️   | **0** | `sim-scaffold`  | Basic project skeleton + argparse     | `python sim.py --help` prints usage.                           |
 |   ⬜️   | **1** | `state-machine` | Dataclass for satellite state         | Unit test: default state values asserted.                      |
 |   ⬜️   | **2** | `cmd-handler`   | Parse AX.25 payload, mutate state     | Send `SET_BEACON_INTERVAL`; state updates; ACK frame produced. |
 |   ⬜️   | **3** | `telemetry-tx`  | Emit downlink payload every N seconds | Subscribed demod receives frame; CRC correct.                  |

--- a/modules/simulator/sim.py
+++ b/modules/simulator/sim.py
@@ -1,0 +1,24 @@
+import argparse
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the argument parser for the simulator CLI."""
+    parser = argparse.ArgumentParser(
+        description="QartvelSat-1 software simulator"
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=5,
+        help="Beacon interval in seconds",
+    )
+    return parser
+
+
+def main(argv=None) -> None:
+    parser = build_parser()
+    parser.parse_args(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entry point
+    main()

--- a/tests/test_sim_cli.py
+++ b/tests/test_sim_cli.py
@@ -1,0 +1,10 @@
+import subprocess
+import sys
+from pathlib import Path
+
+def test_sim_help():
+    root = Path(__file__).resolve().parents[1]
+    script = root / "modules" / "simulator" / "sim.py"
+    result = subprocess.run([sys.executable, str(script), "--help"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "QartvelSat-1" in result.stdout


### PR DESCRIPTION
## Summary
- add a pytest to ensure `sim.py --help` prints the help text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdb8e9320833391c777359f59ec75