### PR TITLE
feat: simulator command handler

### DIFF
--- a/modules/simulator/TODO.md
+++ b/modules/simulator/TODO.md
@@ -4,6 +4,6 @@
 | :----: | :---: | --------------- | ------------------------------------- | -------------------------------------------------------------- |
 |   ☑️   | **0** | `sim-scaffold`  | Basic project skeleton + argparse     | `python sim.py --help` prints usage.                           |
 |   ☑️   | **1** | `state-machine` | Dataclass for satellite state         | Unit test: default state values asserted.                      |
-|   ⬜️   | **2** | `cmd-handler`   | Parse AX.25 payload, mutate state     | Send `SET_BEACON_INTERVAL`; state updates; ACK frame produced. |
+|   ☑️   | **2** | `cmd-handler`   | Parse AX.25 payload, mutate state     | Send `SET_BEACON_INTERVAL`; state updates; ACK frame produced. |
 |   ⬜️   | **3** | `telemetry-tx`  | Emit downlink payload every N seconds | Subscribed demod receives frame; CRC correct.                  |
 |   ⬜️   | **4** | `orbit-toggle`  | Simple vis window on/off              | Config flag triggers no packets outside pass; test passes.     |

--- a/modules/simulator/sim.py
+++ b/modules/simulator/sim.py
@@ -1,6 +1,9 @@
 import argparse
 from dataclasses import dataclass
 
+# Command identifiers (from docs/commands.md)
+SET_BEACON_INTERVAL = 0x10
+
 
 @dataclass
 class SatelliteState:
@@ -10,6 +13,19 @@ class SatelliteState:
     batt_mv: int = 3000
     panel_temp: int = 25
     beacon_interval: int = 5
+
+
+def crc16_ibm(data: bytes) -> int:
+    """Return CRC-16/IBM of *data* (polynomial 0xA001, init 0xFFFF)."""
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ 0xA001
+            else:
+                crc >>= 1
+    return crc & 0xFFFF
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -24,6 +40,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Beacon interval in seconds",
     )
     return parser
+
+
+def handle_command(payload: bytes, state: SatelliteState) -> bytes:
+    """Parse *payload* and mutate *state*. Return ACK bytes."""
+    if len(payload) < 4:
+        raise ValueError("payload too short")
+
+    cmd_id = payload[0]
+    param_len = payload[1]
+    params = payload[2 : 2 + param_len]
+    crc_given = int.from_bytes(payload[2 + param_len : 4 + param_len], "little")
+    if crc16_ibm(payload[: 2 + param_len]) != crc_given:
+        raise ValueError("CRC mismatch")
+
+    if cmd_id == SET_BEACON_INTERVAL and param_len == 1:
+        state.beacon_interval = params[0]
+        status = 0
+    else:
+        status = 1
+
+    return bytes([cmd_id, status])
 
 
 def main(argv=None) -> None:

--- a/tests/test_sim_command.py
+++ b/tests/test_sim_command.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from modules.simulator.sim import (
+    SatelliteState,
+    SET_BEACON_INTERVAL,
+    crc16_ibm,
+    handle_command,
+)
+
+
+def _build_cmd(cmd_id: int, params: list[int]) -> bytes:
+    body = bytes([cmd_id, len(params), *params])
+    crc = crc16_ibm(body)
+    return body + crc.to_bytes(2, "little")
+
+
+def test_set_beacon_interval_command():
+    state = SatelliteState()
+    cmd = _build_cmd(SET_BEACON_INTERVAL, [12])
+    ack = handle_command(cmd, state)
+    assert state.beacon_interval == 12
+    assert ack == bytes([SET_BEACON_INTERVAL, 0])


### PR DESCRIPTION
### What & Why
Implement milestone `cmd-handler` for the simulator. The module can now parse a command payload, update the satellite state, and return an ACK frame.

### How
- added CRC‑16/IBM implementation and `handle_command` in `sim.py`
- created unit test exercising `SET_BEACON_INTERVAL`
- marked milestone 2 as complete in TODO

### Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840449353588333bcaec42c4427416f